### PR TITLE
Add launcher account import (Lunar/vanilla/IAS session reuse)

### DIFF
--- a/mcauth/account_source_store.py
+++ b/mcauth/account_source_store.py
@@ -1,0 +1,92 @@
+import inspect
+import logging
+
+from mcauth.account_sources import (
+    ACCOUNT_SOURCE_PRESETS,
+    get_account_source_preset,
+)
+
+__all__ = ["create_account_source_store"]
+
+
+def create_account_source_store(config, save_config=None, logger=None):
+    """Build a store object mirroring the JS ``createAccountSourceStore`` API.
+
+    Args:
+        config: A mutable mapping. The selection is read from and written to
+            ``config["auth"]["accountSource"]`` (``{"id", "path"}``).
+        save_config: Optional callable invoked with ``config`` after a change.
+            May be sync or async; both are awaited correctly.
+        logger: Optional ``logging.Logger`` (defaults to the ``proxhy`` logger).
+    """
+    logger = logger or logging.getLogger("proxhy")
+    auth = config.setdefault("auth", {})
+
+    def resolve_stored_path(source_id, raw_path):
+        preset = get_account_source_preset(source_id)
+        if preset.id == "custom":
+            return raw_path if raw_path is not None else ""
+
+        trimmed = raw_path.strip() if isinstance(raw_path, str) else ""
+        return trimmed or preset.default_path
+
+    account_source = auth.get("accountSource") or {}
+    selected_id = account_source.get("id") or "lunar"
+    selected_preset = get_account_source_preset(selected_id)
+
+    state = {
+        "id": selected_preset.id,
+        "path": resolve_stored_path(selected_preset.id, account_source.get("path")),
+    }
+
+    async def _maybe_save():
+        if save_config is None:
+            return
+        result = save_config(config)
+        if inspect.isawaitable(result):
+            await result
+
+    class _AccountSourceStore:
+        def list(self):
+            return [
+                {
+                    "id": source.id,
+                    "label": source.label,
+                    "parser": source.parser,
+                    "supported": source.supported,
+                    "default_path": source.default_path,
+                    "selected": source.id == state["id"],
+                    "path": (
+                        state["path"]
+                        if source.id == state["id"]
+                        else resolve_stored_path(source.id, source.default_path)
+                    ),
+                }
+                for source in ACCOUNT_SOURCE_PRESETS
+            ]
+
+        def get(self):
+            preset = get_account_source_preset(state["id"])
+            return {
+                "id": preset.id,
+                "label": preset.label,
+                "parser": preset.parser,
+                "supported": preset.supported,
+                "default_path": preset.default_path,
+                "path": resolve_stored_path(state["id"], state["path"]),
+            }
+
+        async def set(self, id, path=None):
+            preset = get_account_source_preset(id)
+            state["id"] = preset.id
+            state["path"] = resolve_stored_path(preset.id, path)
+            auth["accountSource"] = {"id": state["id"], "path": state["path"]}
+            await _maybe_save()
+            suffix = f" ({state['path']})" if state["path"] else ""
+            logger.info(f"Selected account source {state['id']}{suffix}")
+            return self.get()
+
+        def snapshot(self):
+            return {"selected": self.get(), "presets": self.list()}
+
+    return _AccountSourceStore()

--- a/mcauth/account_sources.py
+++ b/mcauth/account_sources.py
@@ -1,0 +1,94 @@
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from mcauth.session_loader import (
+    DEFAULT_IAS_ACCOUNTS_PATH,
+    DEFAULT_LUNAR_ACCOUNTS_PATH,
+    DEFAULT_VANILLA_ACCOUNTS_PATH,
+    resolve_preset_default_path,
+)
+
+__all__ = [
+    "AccountSourcePreset",
+    "ACCOUNT_SOURCE_PRESETS",
+    "get_account_source_preset",
+]
+
+
+_HOME = Path.home()
+_PLATFORM = sys.platform
+
+
+def _minecraft_root() -> Path:
+    if _PLATFORM == "darwin":
+        return _HOME / "Library" / "Application Support" / "minecraft"
+
+    if _PLATFORM == "win32":
+        return _HOME / "AppData" / "Roaming" / ".minecraft"
+
+    return _HOME / ".minecraft"
+
+
+@dataclass(frozen=True)
+class AccountSourcePreset:
+    id: str
+    label: str
+    parser: str
+    supported: bool
+    default_path: str | Path
+
+
+ACCOUNT_SOURCE_PRESETS: list[AccountSourcePreset] = [
+    AccountSourcePreset(
+        id="lunar",
+        label="Lunar Client",
+        parser="launcher-json",
+        supported=True,
+        default_path=resolve_preset_default_path("lunar", DEFAULT_LUNAR_ACCOUNTS_PATH),
+    ),
+    AccountSourcePreset(
+        id="vanilla",
+        label="Minecraft Launcher",
+        parser="launcher-json",
+        supported=True,
+        default_path=resolve_preset_default_path(
+            "vanilla", DEFAULT_VANILLA_ACCOUNTS_PATH
+        ),
+    ),
+    AccountSourcePreset(
+        id="ias",
+        label="In-Game Account Switcher",
+        parser="ias-json",
+        supported=True,
+        default_path=resolve_preset_default_path("ias", DEFAULT_IAS_ACCOUNTS_PATH),
+    ),
+    AccountSourcePreset(
+        id="labymod",
+        label="LabyMod",
+        parser="unsupported",
+        supported=False,
+        default_path=_minecraft_root() / "LabyMod" / "accounts.json",
+    ),
+    AccountSourcePreset(
+        id="essential",
+        label="Essential",
+        parser="unsupported",
+        supported=False,
+        default_path=_minecraft_root() / "essential",
+    ),
+    AccountSourcePreset(
+        id="custom",
+        label="Custom",
+        parser="auto-json",
+        supported=True,
+        default_path="",
+    ),
+]
+
+
+def get_account_source_preset(source_id: str) -> AccountSourcePreset:
+    return next(
+        (source for source in ACCOUNT_SOURCE_PRESETS if source.id == source_id),
+        ACCOUNT_SOURCE_PRESETS[0],
+    )

--- a/mcauth/session_loader.py
+++ b/mcauth/session_loader.py
@@ -1,0 +1,541 @@
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "DEFAULT_LUNAR_ACCOUNTS_PATH",
+    "DEFAULT_VANILLA_ACCOUNTS_PATH",
+    "DEFAULT_IAS_ACCOUNTS_PATH",
+    "Session",
+    "SelectedProfile",
+    "ProfileHint",
+    "MinecraftProfile",
+    "load_account_source_session",
+    "load_account_source_profile_hint_sync",
+    "load_launcher_json_session",
+    "load_lunar_active_session",
+    "load_launcher_json_session_sync",
+    "count_source_accounts",
+    "find_launcher_account_session",
+    "summarize_account_sources",
+    "resolve_preset_default_path",
+]
+
+
+_HOME = Path.home()
+_PLATFORM = sys.platform  # "win32", "darwin", "linux", ...
+
+
+def _from_home(*segments: str) -> Path:
+    return _HOME.joinpath(*segments)
+
+
+def _first_existing_path(candidates, fallback: Path) -> Path:
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return Path(candidate)
+    return fallback
+
+
+def _lunar_accounts_candidates() -> list[Path]:
+    candidates = [_from_home(".lunarclient", "settings", "game", "accounts.json")]
+
+    if _PLATFORM == "darwin":
+        candidates.insert(
+            0,
+            _from_home(
+                "Library",
+                "Application Support",
+                "lunarclient",
+                "settings",
+                "game",
+                "accounts.json",
+            ),
+        )
+
+    return candidates
+
+
+def _vanilla_accounts_candidates() -> list[Path]:
+    if _PLATFORM == "darwin":
+        base = _from_home("Library", "Application Support", "minecraft")
+        return [
+            base / "launcher_accounts.json",
+            base / "launcher_accounts_microsoft_store.json",
+        ]
+
+    if _PLATFORM == "win32":
+        base = _from_home("AppData", "Roaming", ".minecraft")
+        return [
+            base / "launcher_accounts.json",
+            base / "launcher_accounts_microsoft_store.json",
+        ]
+
+    base = _from_home(".minecraft")
+    return [
+        base / "launcher_accounts.json",
+        base / "launcher_accounts_microsoft_store.json",
+    ]
+
+
+def _ias_accounts_candidates() -> list[Path]:
+    if _PLATFORM == "darwin":
+        return [
+            _from_home(
+                "Library", "Application Support", "minecraft", "config", "ias.json"
+            )
+        ]
+
+    if _PLATFORM == "win32":
+        return [_from_home("AppData", "Roaming", ".minecraft", "config", "ias.json")]
+
+    return [_from_home(".minecraft", "config", "ias.json")]
+
+
+DEFAULT_LUNAR_ACCOUNTS_PATH = _first_existing_path(
+    _lunar_accounts_candidates(), _lunar_accounts_candidates()[0]
+)
+DEFAULT_VANILLA_ACCOUNTS_PATH = _first_existing_path(
+    _vanilla_accounts_candidates(), _vanilla_accounts_candidates()[0]
+)
+DEFAULT_IAS_ACCOUNTS_PATH = _first_existing_path(
+    _ias_accounts_candidates(), _ias_accounts_candidates()[0]
+)
+
+
+# ============================================================================
+# Data structures
+# ============================================================================
+
+
+@dataclass
+class SelectedProfile:
+    id: str  # undashed UUID
+    name: str
+
+
+@dataclass
+class Session:
+    username: str
+    access_token_expires_at: object  # str | int | None (launcher-dependent)
+    session: "SessionInner"
+
+
+@dataclass
+class SessionInner:
+    access_token: str
+    selected_profile: SelectedProfile
+
+
+@dataclass
+class MinecraftProfile:
+    id: str  # undashed UUID
+    name: str
+
+
+@dataclass
+class ProfileHint:
+    username: str
+    minecraft_profile: MinecraftProfile
+
+
+# ============================================================================
+# Parsing / account selection
+# ============================================================================
+
+
+def _undash_uuid(value) -> str:
+    return str("" if value is None else value).replace("-", "")
+
+
+def _parse_json_file(raw: str, error_prefix: str):
+    import json
+
+    try:
+        return json.loads(raw)
+    except ValueError as error:
+        raise ValueError(f"{error_prefix}: {error}") from error
+
+
+def _detect_json_parser(parsed) -> str:
+    if isinstance(parsed, dict) and parsed.get("accounts") and parsed.get(
+        "activeAccountLocalId"
+    ):
+        return "launcher-json"
+
+    if (
+        isinstance(parsed, dict)
+        and isinstance(parsed.get("accounts"), list)
+        and "version" in parsed
+    ):
+        return "ias-json"
+
+    raise ValueError("Unsupported account JSON format")
+
+
+def _select_launcher_account(parsed):
+    active_account_local_id = parsed.get("activeAccountLocalId")
+    if not active_account_local_id:
+        raise ValueError("Launcher accounts file does not define activeAccountLocalId")
+
+    account = (parsed.get("accounts") or {}).get(active_account_local_id)
+    if not account:
+        raise ValueError(
+            f"Launcher active account {active_account_local_id} not found"
+        )
+
+    profile = account.get("minecraftProfile") or {}
+    if not profile.get("id") or not profile.get("name"):
+        raise ValueError(
+            "Launcher active account is missing minecraftProfile.id or "
+            "minecraftProfile.name"
+        )
+
+    return account
+
+
+def _select_ias_account(parsed, options: dict | None = None):
+    options = options or {}
+    preferred_username = str(options.get("preferred_username") or "").strip().lower()
+    accounts = parsed.get("accounts") or []
+
+    def _name_matches(entry) -> bool:
+        return str(entry.get("name") or "").strip().lower() == preferred_username
+
+    if preferred_username:
+        matching = next(
+            (
+                entry
+                for entry in accounts
+                if entry.get("isValid")
+                and entry.get("accessToken")
+                and entry.get("uuid")
+                and _name_matches(entry)
+            ),
+            None,
+        ) or next(
+            (
+                entry
+                for entry in accounts
+                if entry.get("accessToken")
+                and entry.get("uuid")
+                and _name_matches(entry)
+            ),
+            None,
+        )
+
+        if matching:
+            return matching
+
+    account = next(
+        (
+            entry
+            for entry in accounts
+            if entry.get("isValid")
+            and entry.get("accessToken")
+            and entry.get("uuid")
+            and entry.get("name")
+        ),
+        None,
+    ) or next(
+        (
+            entry
+            for entry in accounts
+            if entry.get("accessToken") and entry.get("uuid") and entry.get("name")
+        ),
+        None,
+    )
+
+    if not account:
+        raise ValueError("IAS config does not contain a usable account")
+
+    return account
+
+
+# ============================================================================
+# Session / profile-hint builders
+# ============================================================================
+
+
+def _build_launcher_session(account) -> Session:
+    if not account.get("accessToken"):
+        raise ValueError("Launcher active account has no accessToken")
+
+    profile = account["minecraftProfile"]
+    return Session(
+        username=account.get("username"),
+        access_token_expires_at=account.get("accessTokenExpiresAt"),
+        session=SessionInner(
+            access_token=account["accessToken"],
+            selected_profile=SelectedProfile(
+                id=_undash_uuid(profile["id"]),
+                name=profile["name"],
+            ),
+        ),
+    )
+
+
+def _build_ias_session(account) -> Session:
+    return Session(
+        username=account.get("name"),
+        access_token_expires_at=None,
+        session=SessionInner(
+            access_token=account["accessToken"],
+            selected_profile=SelectedProfile(
+                id=_undash_uuid(account["uuid"]),
+                name=account["name"],
+            ),
+        ),
+    )
+
+
+def _build_launcher_profile_hint(account) -> ProfileHint:
+    profile = account["minecraftProfile"]
+    return ProfileHint(
+        username=account.get("username"),
+        minecraft_profile=MinecraftProfile(
+            id=_undash_uuid(profile["id"]),
+            name=profile["name"],
+        ),
+    )
+
+
+def _build_ias_profile_hint(account) -> ProfileHint:
+    return ProfileHint(
+        username=account.get("name"),
+        minecraft_profile=MinecraftProfile(
+            id=_undash_uuid(account["uuid"]),
+            name=account["name"],
+        ),
+    )
+
+
+def _load_account_source_json(raw: str, parser: str = "auto-json", options=None):
+    parsed = _parse_json_file(raw, "Failed to parse account source JSON")
+    selected_parser = _detect_json_parser(parsed) if parser == "auto-json" else parser
+
+    if selected_parser == "launcher-json":
+        return selected_parser, parsed, _select_launcher_account(parsed)
+
+    if selected_parser == "ias-json":
+        return selected_parser, parsed, _select_ias_account(parsed, options)
+
+    raise ValueError(f"Unsupported account source parser {selected_parser}")
+
+
+def _default_path_for_parser(parser: str) -> Path:
+    if parser == "ias-json":
+        return DEFAULT_IAS_ACCOUNTS_PATH
+    return DEFAULT_LUNAR_ACCOUNTS_PATH
+
+
+def _resolve_vanilla_accounts_path(
+    preferred_path: Path | str = DEFAULT_VANILLA_ACCOUNTS_PATH,
+) -> Path:
+    return _first_existing_path(
+        [preferred_path, *_vanilla_accounts_candidates()], Path(preferred_path)
+    )
+
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+
+async def load_account_source_session(
+    accounts_path: Path | str | None = None,
+    parser: str = "auto-json",
+    options: dict | None = None,
+) -> Session:
+    """Asynchronously read an account file and return a usable session."""
+    path = Path(accounts_path) if accounts_path else _default_path_for_parser(parser)
+    raw = await asyncio.to_thread(path.read_text, "utf-8")
+    selected_parser, _parsed, account = _load_account_source_json(raw, parser, options)
+
+    if selected_parser == "launcher-json":
+        return _build_launcher_session(account)
+
+    if selected_parser == "ias-json":
+        return _build_ias_session(account)
+
+    raise ValueError(f"Unsupported account source parser {selected_parser}")
+
+
+def load_account_source_profile_hint_sync(
+    accounts_path: Path | str | None = None,
+    parser: str = "auto-json",
+    options: dict | None = None,
+) -> ProfileHint:
+    """Synchronously read an account file and return only its profile hint."""
+    path = Path(accounts_path) if accounts_path else _default_path_for_parser(parser)
+    raw = path.read_text("utf-8")
+    selected_parser, _parsed, account = _load_account_source_json(raw, parser, options)
+
+    if selected_parser == "launcher-json":
+        return _build_launcher_profile_hint(account)
+
+    if selected_parser == "ias-json":
+        return _build_ias_profile_hint(account)
+
+    raise ValueError(f"Unsupported account source parser {selected_parser}")
+
+
+async def load_launcher_json_session(
+    accounts_path: Path | str = DEFAULT_LUNAR_ACCOUNTS_PATH,
+) -> Session:
+    return await load_account_source_session(accounts_path, "launcher-json")
+
+
+async def load_lunar_active_session(
+    accounts_path: Path | str = DEFAULT_LUNAR_ACCOUNTS_PATH,
+) -> Session:
+    return await load_launcher_json_session(accounts_path)
+
+
+def load_launcher_json_session_sync(
+    accounts_path: Path | str = DEFAULT_LUNAR_ACCOUNTS_PATH,
+) -> ProfileHint:
+    return load_account_source_profile_hint_sync(accounts_path, "launcher-json")
+
+
+def count_source_accounts(
+    accounts_path: Path | str, parser: str = "auto-json"
+) -> int:
+    """Return how many usable accounts an account file contains.
+
+    - ``launcher-json`` files store accounts in a mapping; each entry with a
+      ``minecraftProfile`` (id + name) is counted.
+    - ``ias-json`` files store accounts in a list; each entry with a token,
+      uuid and name is counted.
+
+    Raises ``FileNotFoundError`` if the file is missing and ``ValueError`` if it
+    cannot be parsed.
+    """
+    raw = Path(accounts_path).read_text("utf-8")
+    parsed = _parse_json_file(raw, "Failed to parse account source JSON")
+    selected_parser = _detect_json_parser(parsed) if parser == "auto-json" else parser
+
+    if selected_parser == "launcher-json":
+        accounts = parsed.get("accounts") or {}
+        return sum(
+            1
+            for account in accounts.values()
+            if (account.get("minecraftProfile") or {}).get("id")
+            and (account.get("minecraftProfile") or {}).get("name")
+        )
+
+    if selected_parser == "ias-json":
+        accounts = parsed.get("accounts") or []
+        return sum(
+            1
+            for entry in accounts
+            if entry.get("accessToken") and entry.get("uuid") and entry.get("name")
+        )
+
+    raise ValueError(f"Unsupported account source parser {selected_parser}")
+
+
+def find_launcher_account_session(username: str) -> tuple[str, Session] | None:
+    """Find an already-authenticated session for ``username`` in any launcher.
+
+    Scans every supported preset's default account file (Lunar, vanilla
+    launcher, IAS) for an account whose profile name matches ``username``
+    (case-insensitive) and that carries a usable access token. Returns a
+    ``(source_id, Session)`` tuple, or ``None`` if no match is found.
+    """
+    from mcauth.account_sources import ACCOUNT_SOURCE_PRESETS
+
+    target = str(username or "").strip().lower()
+    if not target:
+        return None
+
+    for preset in ACCOUNT_SOURCE_PRESETS:
+        if not preset.supported or not preset.default_path:
+            continue
+
+        path = Path(preset.default_path)
+        if not path.exists():
+            continue
+
+        try:
+            parsed = _parse_json_file(
+                path.read_text("utf-8"), "Failed to parse account source JSON"
+            )
+            parser = (
+                _detect_json_parser(parsed)
+                if preset.parser == "auto-json"
+                else preset.parser
+            )
+        except (ValueError, OSError):
+            continue
+
+        if parser == "launcher-json":
+            for account in (parsed.get("accounts") or {}).values():
+                profile = account.get("minecraftProfile") or {}
+                name = str(profile.get("name") or "").strip().lower()
+                if name == target and account.get("accessToken") and profile.get("id"):
+                    return preset.id, _build_launcher_session(account)
+
+        elif parser == "ias-json":
+            for entry in parsed.get("accounts") or []:
+                name = str(entry.get("name") or "").strip().lower()
+                if (
+                    name == target
+                    and entry.get("accessToken")
+                    and entry.get("uuid")
+                ):
+                    return preset.id, _build_ias_session(entry)
+
+    return None
+
+
+def summarize_account_sources() -> list[dict]:
+    """Scan every supported preset's default location and count its accounts.
+
+    Returns one dict per supported source with keys ``id``, ``label``,
+    ``path``, ``count`` and ``error`` (``None`` on success). Sources whose file
+    does not exist are reported with ``count == 0`` and ``error == "not found"``.
+    """
+    from mcauth.account_sources import ACCOUNT_SOURCE_PRESETS
+
+    summary = []
+    for preset in ACCOUNT_SOURCE_PRESETS:
+        if not preset.supported or not preset.default_path:
+            continue
+
+        path = Path(preset.default_path)
+        entry = {
+            "id": preset.id,
+            "label": preset.label,
+            "path": str(path),
+            "count": 0,
+            "error": None,
+        }
+
+        if not path.exists():
+            entry["error"] = "not found"
+        else:
+            try:
+                entry["count"] = count_source_accounts(path, preset.parser)
+            except (ValueError, OSError) as error:
+                entry["error"] = str(error)
+
+        summary.append(entry)
+
+    return summary
+
+
+def resolve_preset_default_path(source_id: str, fallback_path: str | Path = "") -> Path | str:
+    if source_id == "vanilla":
+        return _resolve_vanilla_accounts_path(
+            fallback_path or DEFAULT_VANILLA_ACCOUNTS_PATH
+        )
+
+    if source_id == "ias":
+        return DEFAULT_IAS_ACCOUNTS_PATH
+
+    if source_id == "lunar":
+        return DEFAULT_LUNAR_ACCOUNTS_PATH
+
+    return fallback_path

--- a/plugins/login.py
+++ b/plugins/login.py
@@ -15,6 +15,7 @@ import orjson
 
 import mcauth as auth
 from mcauth.errors import AuthException, InvalidCredentials
+from mcauth.session_loader import find_launcher_account_session
 from petty.events import listen_client, listen_server, subscribe
 from petty.net import ServerStream, State
 from petty.protocol.crypt import (
@@ -72,6 +73,7 @@ class LoginPlugin:
         }
 
         self.access_token = ""
+        self.launcher_session = None
         self.secret: bytes = b""
 
         self.secret_task: asyncio.Task | None = None
@@ -172,11 +174,21 @@ class LoginPlugin:
     async def packet_login_start(self: ProxhyPlugin, buff: Buffer):
         self.username = buff.unpack(String)
 
+        self.launcher_session = None
         if not auth.user_exists(self.username):
-            self.logger.debug(f"user {self.username} does not exist; logging in")
-            return await self.login()
+            # Not logged into Proxhy itself yet; try to reuse a session from a
+            # launcher (Lunar Client, vanilla launcher, IAS) the user already
+            # authenticated with, before falling back to the device-code flow.
+            self.launcher_session = find_launcher_account_session(self.username)
+            if self.launcher_session is None:
+                self.logger.debug(f"user {self.username} does not exist; logging in")
+                return await self.login()
 
-        if auth.token_needs_refresh(self.username):
+            source_id, _session = self.launcher_session
+            self.logger.info(
+                f"reusing existing {source_id} session for {self.username}"
+            )
+        elif auth.token_needs_refresh(self.username):
             self.logger.debug(
                 f"user {self.username} needs a token refresh; regenerating credentials"
             )
@@ -222,9 +234,14 @@ class LoginPlugin:
         )
 
         if self.CONNECT_HOST[0] not in {"localhost", "127.0.0.1", "::1"}:
-            self.access_token, self.username, self.uuid = await auth.load_auth_info(
-                self.username
-            )
+            if self.launcher_session is not None:
+                _source_id, session = self.launcher_session
+                self.access_token = session.session.access_token
+                self.uuid = uuid.UUID(session.session.selected_profile.id)
+            else:
+                self.access_token, self.username, self.uuid = (
+                    await auth.load_auth_info(self.username)
+                )
 
             async with Cache() as cache:
                 if self.CONNECT_HOST in cache:

--- a/proxhy/main.py
+++ b/proxhy/main.py
@@ -12,6 +12,7 @@ from importlib.metadata import version
 from platformdirs import user_log_path
 
 import mcauth as auth
+from mcauth.session_loader import summarize_account_sources
 from petty.endpoints import Proxy
 from proxhy.proxhy import Proxhy
 from proxhy.utils import zero_pad_calver
@@ -35,6 +36,23 @@ logger = logging.getLogger("proxhy")
 instances: list[Proxy] = []
 
 auth.set_client_id("6dd7ede8-1d77-4fff-a7ea-6e07c09d6163")
+
+
+def log_account_sources():
+    """Log how many accounts were found in each supported launcher."""
+    for source in summarize_account_sources():
+        if source["error"] == "not found":
+            logger.info(f"{source['label']}: not installed ({source['path']})")
+        elif source["error"]:
+            logger.warning(
+                f"{source['label']}: could not read accounts ({source['error']})"
+            )
+        else:
+            count = source["count"]
+            logger.info(
+                f"{source['label']}: found {count} account{'' if count == 1 else 's'} "
+                f"({source['path']})"
+            )
 
 
 def parse_args():
@@ -191,6 +209,7 @@ async def start(host: str = "localhost", port: int = 41223) -> ProxhyServer:
     logger.info(
         f"Started proxhy v{zero_pad_calver(version('proxhy'))} on {host}:{port} -> {args.remote_host}:{args.remote_port} ({args.fake_host}:{args.fake_port})"
     )
+    log_account_sources()
     if args.dev:
         logger.setLevel(logging.DEBUG)
         logger.info("DEV MODE ACTIVATED")


### PR DESCRIPTION
## What
On first join, Proxhy now reuses a Minecraft session you've already
authenticated in another launcher (Lunar Client, the vanilla Minecraft
launcher, or the In-Game Account Switcher mod) instead of forcing the
Microsoft device-code login.

## Why
Previously the proxy only checked its own encrypted token store. Joining
with an account that was already logged in via Lunar still triggered the
full device-code flow ("You have not logged into Proxhy with this account
yet!"). This reads the token that's already on disk and logs you straight in.

## How it works
- `mcauth/session_loader.py` reads the launcher account databases:
  - `launcher-json` — Lunar Client `accounts.json` and the vanilla launcher `launcher_accounts.json`
  - `ias-json` — In-Game Account Switcher `ias.json`

  It resolves the default paths per OS (Windows/macOS/Linux), builds a
  session (access token + selected profile), and can search every source
  for a session matching a given username.
- `plugins/login.py`: on first login for a username, look it up in the
  installed launchers and reuse that access token/UUID. Only fall back to
  the device-code flow when no launcher session is found. Accounts already
  stored by Proxhy keep using Proxhy's own (refreshable) credentials.
- `proxhy/main.py`: on startup, log how many accounts were found in each
  launcher, e.g. `Lunar Client: found 8 accounts (...accounts.json)`.
- `mcauth/account_sources.py` / `account_source_store.py`: presets for each
  supported launcher plus a small store to persist the selected source.

## Notes / limitations
- Launcher access tokens expire (~24h) and are refreshed by the launcher
  itself, not by Proxhy (Proxhy has no refresh token for them). If the
  reused token is expired, reload the account in the launcher, or log into
  Proxhy directly once so Proxhy manages a refreshable token.